### PR TITLE
タグ詳細ページに関連タグ

### DIFF
--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+	Plugin Name: Similar Tag Widget Plugin
+	Plugin URI:
+	Plugin Description: Displary similar tag widget
+	Plugin Version: 1.0
+	Plugin Date: 2016-07-11
+	Plugin Author: 38qa.net
+	Plugin Author URI: http://www.question2answer.org/
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.5
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// widget
+qa_register_plugin_module('widget', 'qa-similar-tag-widget.php', 'qa_similar_tag_widget', 'Similar Tag Widget');

--- a/qa-similar-tag-widget.php
+++ b/qa-similar-tag-widget.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+	Question2Answer Plugin: Similar Tag Widget
+*/
+
+class qa_similar_tag_widget {
+
+	function allow_template($template)
+	{
+		$allow=false;
+
+		return $allow;
+	}
+
+	function allow_region($region)
+	{
+		$allow=false;
+
+		return $allow;
+	}
+
+	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
+	{
+
+	}
+}
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-similar-tag-widget.php
+++ b/qa-similar-tag-widget.php
@@ -3,26 +3,41 @@
 /*
 	Question2Answer Plugin: Similar Tag Widget
 */
+require_once QA_PLUGIN_DIR.'q2a-similar-tag-widget/similar-tag-db.php';
 
 class qa_similar_tag_widget {
 
 	function allow_template($template)
 	{
-		$allow=false;
-
-		return $allow;
+		return ($template === 'tag');
 	}
 
 	function allow_region($region)
 	{
-		$allow=false;
-
-		return $allow;
+		return true;
 	}
 
 	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
 	{
+		$requests = explode('/', $request);
+		$tag = $requests[1];
+		$stdb = new similar_tag_db();
+		$tags = qa_tagstring_to_tags($stdb->get_similar_tag_words($tag));
 
+		$themeobject->output('<div class="qa-q-item-tags"><h4>','関連タグ','</h4>');
+		$themeobject->output('<ul class="qa-q-item-tag-list">');
+		foreach ($tags as $tag) {
+			$themeobject->output('<li class="qa-q-item-tag-item">', $this->add_link($tag), '</li>');
+		}
+		$themeobject->output('</ul>');
+		$themeobject->output('</div>');
+		$themeobject->output('<div class="qa-q-item-clear"></div>');
+	}
+
+	function add_link($tag) {
+		return '<a href="' . qa_path_html('tag/'.$tag) .
+				'" class="qa-tag-link">' .
+				 qa_html($tag) . '</a>';
 	}
 }
 /*

--- a/similar-tag-db.php
+++ b/similar-tag-db.php
@@ -1,0 +1,20 @@
+<?php
+
+class similar_tag_db
+{
+	public function get_similar_tags($wordid, $cnt)
+	{
+		$sql = "SELECT wordid
+FROM ^posttags
+WHERE postid in (
+SELECT postid FROM ^posttags WHERE wordid = #
+)
+AND wordid != #
+GROUP BY wordid
+ORDER BY count(wordid) DESC
+LIMIT #";
+
+		$result = qa_db_query_sub($sql, $wordid, $wordid, $cnt);
+		return $result;
+	}
+}

--- a/similar-tag-db.php
+++ b/similar-tag-db.php
@@ -2,6 +2,46 @@
 
 class similar_tag_db
 {
+	const SIMILAR_TAGS = 'similar_tags';
+	const SIMILAR_COUNT = 5;
+
+	/**
+	 * 全てのタグの類似タグを更新
+	 * @return int	処理件数
+	 */
+	public function update_all_similar_gats()
+	{
+		$cnt = 0;
+		$all_tags = $this->get_all_tags();
+		foreach ($all_tags as $tag) {
+			$sim_tags = $this->get_similar_tags($tag, self::SIMILAR_COUNT);
+			$this->set_similar_tags($tag, $sim_tags);
+			$cnt++;
+		}
+		return $cnt;
+	}
+
+	/**
+	 * 類似タグをMETAテーブルから取得
+	 * @param  int $wordid タグのwordid
+	 * @return string        類似タグ、カンマ区切り
+	 */
+	public function get_similar_tag_metas($wordid)
+	{
+		$sql = "SELECT content
+FROM ^tagmetas
+WHERE tag=$ AND title=$
+";
+
+		return qa_db_read_one_value(qa_db_query_sub($sql, $wordid, self::SIMILAR_TAGS));
+	}
+
+	/**
+	 * 類似タグを取得
+	 * @param  int $wordid タグのwordid
+	 * @param  int $cnt    取得する類似タグの数
+	 * @return array     類似タグのwordid
+	 */
 	public function get_similar_tags($wordid, $cnt)
 	{
 		$sql = "SELECT wordid
@@ -14,7 +54,84 @@ GROUP BY wordid
 ORDER BY count(wordid) DESC
 LIMIT #";
 
-		$result = qa_db_query_sub($sql, $wordid, $wordid, $cnt);
-		return $result;
+		return qa_db_read_all_values(qa_db_query_sub($sql, $wordid, $wordid, $cnt));
 	}
+
+	/**
+	 * 類似タグをテーブルに保存する
+	 * @param int $wordid タグのwordid
+	 * @param array $tags   類似タグのwordid
+	 */
+	public function set_similar_tags($wordid, $tags)
+	{
+		if(isset($wordid) && count($tags) > 0) {
+			if ($this->exists_similar_tags($wordid)) {
+				$this->update_similar_tags($wordid, $tags);
+			} else {
+				$this->create_similar_tags($wordid, $tags);
+			}
+		}
+	}
+
+	/**
+	 * ポストに付いている全てのタグを取得
+	 * @return array タグのwordid
+	 */
+	private function get_all_tags()
+	{
+
+		$sql = "SELECT DISTINCT wordid FROM ^posttags";
+
+		return qa_db_read_all_values(qa_db_query_sub($sql));
+	}
+
+	/**
+	 * 類似タグを新規作成
+	 * @param  int $wordid タグのwordid
+	 * @param  array $tags 類似タグのwordid
+	 */
+	private function create_similar_tags($wordid, $tags)
+	{
+		qa_db_query_sub(
+			"INSERT INTO ^tagmetas (tag, title, content)
+VALUES ($, $, $)
+",
+			$wordid, self::SIMILAR_TAGS, implode(',', $tags)
+		);
+
+	}
+
+	/**
+	 * 類似タグを更新
+	 * @param  int $wordid タグのwordid
+	 * @param  array $tags   類似タグのwordidon]
+	 */
+	private function update_similar_tags($wordid, $tags)
+	{
+		qa_db_query_sub(
+			"UPDATE ^tagmetas
+SET content=$
+WHERE tag=$ AND title=$
+",
+			implode(',', $tags), $wordid, self::SIMILAR_TAGS
+		);
+	}
+
+	/**
+	 * テーブルに類似タグが保存されているか
+	 * @param  int $wordid タグのwordid
+	 * @return boolean         保存されていればtrue
+	 */
+	private function exists_similar_tags($wordid)
+	{
+		$sql = "SELECT count(*) as cnt
+FROM ^tagmetas WHERE tag = $ AND title = $
+";
+		$result = qa_db_read_one_value(qa_db_query_sub($sql, $wordid, self::SIMILAR_TAGS));
+		if (isset($result) && $result > 0) {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/similar-tag-script.php
+++ b/similar-tag-script.php
@@ -9,7 +9,9 @@ error_log('script start');
 require_once QA_PLUGIN_DIR.'q2a-similar-tag-widget/similar-tag-db.php';
 $start = microtime(true);
 if (qa_using_tags()) {
-	// error_log('処理件数: ' . $count);
+	$stdb = new similar_tag_db();;
+	$cnt = $stdb->update_all_similar_gats();
+	error_log('処理件数: ' . $cnt);
 }
 $end = microtime(true);
 error_log("処理時間：" . ($end - $start) . "秒");

--- a/similar-tag-script.php
+++ b/similar-tag-script.php
@@ -1,0 +1,21 @@
+<?php
+
+if (!defined('QA_VERSION')) {
+	require_once dirname(empty($_SERVER['SCRIPT_FILENAME']) ? __FILE__ : $_SERVER['SCRIPT_FILENAME']).'/../../qa-include/qa-base.php';
+}
+
+error_log('-----------------------------------');
+error_log('script start');
+require_once QA_PLUGIN_DIR.'q2a-similar-tag-widget/similar-tag-db.php';
+$start = microtime(true);
+if (qa_using_tags()) {
+	// error_log('処理件数: ' . $count);
+}
+$end = microtime(true);
+error_log("処理時間：" . ($end - $start) . "秒");
+error_log('script finished');
+error_log('-----------------------------------');
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/


### PR DESCRIPTION
- スクリプト実行で qa_tagmetas テーブルに関連タグを保存
- ウィジェットでタグ詳細ページに表示

はじめはwordidで保存していましたがそれだと表示するとき使いづらいので
word で保存するように変更しました
